### PR TITLE
chore(release): v0.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "directive"
-version = "0.0.3"
+version = "0.0.4"
 description = "Directive CLI and MCP server scaffolding for file-driven agent context."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Automated release PR for v0.0.4.

- Bumps project.version in pyproject.toml
- Merging this PR to main will trigger the PyPI publish workflow