### PR TITLE
feat(mcp): enable autoStart for Directive server

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -4,7 +4,8 @@
       "type": "stdio",
       "command": "/usr/bin/env",
       "args": ["-S", "uv", "run", "-q", "-m", "directive.cli", "mcp", "serve"],
-      "transport": "stdio"
+      "transport": "stdio",
+      "autoStart": true
     }
   }
 }

--- a/directive/specs/mcp-autostart/impact.md
+++ b/directive/specs/mcp-autostart/impact.md
@@ -1,0 +1,19 @@
+# Impact Analysis — MCP Auto‑Start for Cursor
+
+## Modules/packages likely touched
+- `.cursor/mcp.json` (enable `autoStart` for the `Directive` server)
+
+## Contracts to update (APIs, events, schemas, migrations)
+- None. Editor configuration only; no public API or schema changes.
+
+## Risks
+- Security: None; no new secrets or permissions.
+- Performance/Availability: Minimal startup overhead when opening the workspace.
+- Data integrity: None.
+
+## Observability needs
+- Logs: Rely on Cursor’s MCP server start logs for diagnostics on failure.
+- Metrics: None.
+- Alerts: None.
+
+

--- a/directive/specs/mcp-autostart/spec.md
+++ b/directive/specs/mcp-autostart/spec.md
@@ -1,0 +1,42 @@
+# Spec (per PR)
+
+**Feature name**: MCP Auto‑Start for Cursor
+**One-line summary**: Ensure the `Directive` MCP server auto‑starts in Cursor by setting `autoStart: true` in `.cursor/mcp.json`.
+
+---
+
+## Problem
+Today, the MCP server must be started manually, adding friction each time the workspace opens. This slows feedback loops and causes confusion when the assistant cannot access the server context until it is started.
+
+## Goal
+Make the MCP server available immediately when the workspace opens in Cursor by enabling auto‑start in the project’s `.cursor/mcp.json`.
+
+## Success Criteria
+- [ ] Opening the repository in Cursor starts the `Directive` MCP server automatically
+- [ ] No manual start action is required in typical workflows
+- [ ] No behavior changes outside of MCP startup
+
+## User Story
+As a developer using Cursor with the Directive MCP server, I want the server to start automatically when I open the project so I can use MCP capabilities without manual setup.
+
+## Flow / States
+- Happy path: Open project in Cursor → MCP server `Directive` auto‑starts via config → assistant can call tools immediately.
+- Edge case: If the server fails to start (e.g., missing environment), Cursor shows an error; logs indicate the failure and next steps.
+
+## UX Links
+- N/A
+
+## Requirements
+- Must add `"autoStart": true` to the `Directive` server entry in `.cursor/mcp.json` under `mcpServers`.
+- Must not change command, args, or transport for the existing server entry.
+- Must maintain JSON structure and formatting.
+
+## Acceptance Criteria
+- Given the repo is opened in Cursor, when `.cursor/mcp.json` contains `autoStart: true` for `Directive`, then the MCP server starts automatically without manual action.
+- Negative: Given a typo such as `autoRestart`, when the repo is opened, then the server does not auto‑start (ensuring we used the correct key `autoStart`).
+
+## Non-Goals
+- Introducing new servers, transports, or arguments.
+- Changing global user settings (only the repo’s `.cursor/mcp.json` is updated).
+
+

--- a/directive/specs/mcp-autostart/tdr.md
+++ b/directive/specs/mcp-autostart/tdr.md
@@ -1,0 +1,55 @@
+# Technical Design Review (TDR) — MCP Auto‑Start for Cursor
+
+**Author**: <agent or engineer>  
+**Date**: <YYYY-MM-DD>  
+**Links**: Spec (`/directive/specs/mcp-autostart/spec.md`), Impact (`/directive/specs/mcp-autostart/impact.md`)
+
+---
+
+## 1. Summary
+Enable automatic startup of the `Directive` MCP server in Cursor by setting `autoStart: true` in `.cursor/mcp.json`. This removes the manual step to start the server and makes MCP capabilities available immediately.
+
+## 2. Decision Drivers & Non‑Goals
+- Drivers: reduce friction; ensure consistent availability of MCP tools on project open.
+- Non‑Goals: adding/removing servers; changing transports or arguments; modifying global user settings.
+
+## 3. Current State — Codebase Map (concise)
+- `.cursor/mcp.json` defines `mcpServers.Directive` with `type`, `command`, `args`, and `transport` but no `autoStart` flag.
+
+## 4. Proposed Design (high level, implementation‑agnostic)
+- Add `"autoStart": true` to the `Directive` server block in `.cursor/mcp.json`.
+- Do not alter command/args/transport.
+
+## 5. Alternatives Considered
+- Manual start: acceptable but adds repeated friction; rejected.
+- Custom scripts or extensions: unnecessary for a single‑flag change.
+
+## 6. Data Model & Contract Changes
+- None.
+
+## 7. Security, Privacy, Compliance
+- No additional surface area; same server process started automatically.
+
+## 8. Observability & Operations
+- Use Cursor’s server start logs for troubleshooting failed starts.
+
+## 9. Rollout & Migration
+- Single change in repo config; no migration required.
+
+## 10. Test Strategy & Spec Coverage (TDD)
+- Manual check: open repo in Cursor and verify server auto‑starts.
+- Negative check: confirm a wrong key (e.g., `autoRestart`) does not auto‑start (ensures correctness of `autoStart`).
+
+## 11. Risks & Open Questions
+- Minimal risk; ensure JSON remains valid.
+
+## 12. Milestones / Plan (post‑approval)
+1) Add spec/impact/tdr.  
+2) Update `.cursor/mcp.json` with `autoStart: true`.  
+3) Open PR and verify by reopening workspace.
+
+---
+
+**Approval Gate**: Do not start coding until this TDR is reviewed and approved in the PR.
+
+


### PR DESCRIPTION
This PR enables automatic startup of the Directive MCP server in Cursor by adding `autoStart`: true to .cursor/mcp.json.\n\nChanges:\n- Add `autoStart`: true to `.cursor/mcp.json`\n- Add specs under `directive/specs/mcp-autostart/` (spec, impact, TDR)\n\nSpecs:\n- directive/specs/mcp-autostart/spec.md\n- directive/specs/mcp-autostart/impact.md\n- directive/specs/mcp-autostart/tdr.md\n\nAcceptance:\n- Opening the repo in Cursor should auto-start the MCP server without manual action.,